### PR TITLE
Fix Windows path bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,23 +74,23 @@ class WebpackWatchedGlobEntries {
     }
 
     /**
-     *
+     * Create webpack file entry object
      * @param globString
      * @param globOptions
      * @param basename_as_entry_name
-     * @returns {{}}
+     * @returns {Object}
      */
     static getFiles(globString, globOptions, basename_as_entry_name) {
-
-        let files = {};
-        let globBaseOptions = globBase(globString);
+        const files = {};
+        const globBaseOptions = globBase(globString);
 
         glob.sync(globString, globOptions).forEach(function (file) {
-
             // Format the entryName
-            let entryName = file.replace(globBaseOptions.base + '/', '');
-
-            entryName = entryName.replace(path.extname(entryName), '');
+            let entryName = path
+                .relative(globBaseOptions.base, file)
+                .replace(path.extname(file), '')
+                .split(path.sep)
+                .join('/')
 
             if (basename_as_entry_name) {
                 entryName = path.basename(entryName);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "webpack-watched-glob-entries-plugin",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "description": "Webpack plugin to glob directories for entry files and also watch them for changes",
     "main": "index.js",
     "repository": "https://github.com/Milanzor/webpack-watched-glob-entries-plugin",


### PR DESCRIPTION
**Issue**

In case of a windows based system, the bug caused webpack to emit no files at all.
This is due to the fact, that windows file systems use the backslash characters as path separators.

**Solution**

Use `path.sep` & `path.relative` to create always the same bundle name for each file.
