### PR TITLE
Updates yarn command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Provides a way to glob for entry files in Webpack `watch` and `non-watch` modes.
 Install through NPM or Yarn =>
 
 ```sh
-yarn install webpack-watched-glob-entries-plugin -D
+yarn add webpack-watched-glob-entries-plugin -D
 ```
 
 or


### PR DESCRIPTION
Hi!

Tiny change to the readme. Running it as is results in:

```bash
$ yarn install webpack-watched-glob-entries-plugin -D
yarn install v1.3.2
error `install` has been replaced with `add` to add new dependencies. Run "yarn add webpack-watched-glob-entries-plugin --dev" instead.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

Thank you for your work!