### PR TITLE
Fix to the test fail in node v18.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "webpack-watched-glob-entries-plugin",
-    "version": "2.2.4",
+    "version": "2.2.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "webpack-watched-glob-entries-plugin",
-            "version": "2.2.4",
+            "version": "2.2.5",
             "license": "MIT",
             "dependencies": {
                 "glob": "^7.1.6",
@@ -16,11 +16,11 @@
                 "chai": "^4.2.0",
                 "mocha": "^10.0.0",
                 "rimraf": "^3.0.2",
-                "webpack": "^5.11.1",
-                "webpack-cli": "^4.3.1"
+                "webpack": "^5.75.0",
+                "webpack-cli": "^5.0.1"
             },
             "engines": {
-                "node": ">=10.0.0"
+                "node": ">=12.0.0 <=18"
             },
             "optionalDependencies": {
                 "fsevents": "^2.3.2"
@@ -84,19 +84,19 @@
             "dev": true
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.14",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
-            "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+            "version": "0.3.17",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+            "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
             "dev": true,
             "dependencies": {
-                "@jridgewell/resolve-uri": "^3.0.3",
-                "@jridgewell/sourcemap-codec": "^1.4.10"
+                "@jridgewell/resolve-uri": "3.1.0",
+                "@jridgewell/sourcemap-codec": "1.4.14"
             }
         },
         "node_modules/@types/eslint": {
-            "version": "7.2.6",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.6.tgz",
-            "integrity": "sha512-I+1sYH+NPQ3/tVqCeUSBwTE/0heyvtXqpIopUUArlBm0Kpocb8FbMa3AZ/ASKIFpN3rnEx932TTXDbt9OXsNDw==",
+            "version": "8.4.10",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.10.tgz",
+            "integrity": "sha512-Sl/HOqN8NKPmhWo2VBEPm0nvHnu2LL3v9vKo8MEq0EtbJ4eVzGPl41VNPvn5E1i5poMk4/XD8UriLHpJvEP/Nw==",
             "dev": true,
             "dependencies": {
                 "@types/estree": "*",
@@ -104,9 +104,9 @@
             }
         },
         "node_modules/@types/eslint-scope": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.0.tgz",
-            "integrity": "sha512-O/ql2+rrCUe2W2rs7wMR+GqPRcgB6UiqN5RhrR5xruFlY7l9YLMn0ZkDzjoHLeiFkR8MCQZVudUuuvQ2BLC9Qw==",
+            "version": "3.7.4",
+            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
+            "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
             "dev": true,
             "dependencies": {
                 "@types/eslint": "*",
@@ -114,21 +114,21 @@
             }
         },
         "node_modules/@types/estree": {
-            "version": "0.0.45",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.45.tgz",
-            "integrity": "sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==",
+            "version": "0.0.51",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+            "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
             "dev": true
         },
         "node_modules/@types/json-schema": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
-            "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+            "version": "7.0.11",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+            "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "14.14.20",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.20.tgz",
-            "integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A==",
+            "version": "18.11.15",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.15.tgz",
+            "integrity": "sha512-VkhBbVo2+2oozlkdHXLrb3zjsRkpdnaU2bXmX8Wgle3PUi569eLRaHGlgETQHR7lLL1w7GiG3h9SnePhxNDecw==",
             "dev": true
         },
         "node_modules/@ungap/promise-all-settled": {
@@ -138,199 +138,188 @@
             "dev": true
         },
         "node_modules/@webassemblyjs/ast": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.1.tgz",
-            "integrity": "sha512-uMu1nCWn2Wxyy126LlGqRVlhdTOsO/bsBRI4dNq3+6SiSuRKRQX6ejjKgh82LoGAPSq72lDUiQ4FWVaf0PecYw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
+            "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
             "dev": true,
             "dependencies": {
-                "@webassemblyjs/helper-module-context": "1.9.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.9.1",
-                "@webassemblyjs/wast-parser": "1.9.1"
+                "@webassemblyjs/helper-numbers": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
             }
         },
         "node_modules/@webassemblyjs/floating-point-hex-parser": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.1.tgz",
-            "integrity": "sha512-5VEKu024RySmLKTTBl9q1eO/2K5jk9ZS+2HXDBLA9s9p5IjkaXxWiDb/+b7wSQp6FRdLaH1IVGIfOex58Na2pg==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
+            "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
             "dev": true
         },
         "node_modules/@webassemblyjs/helper-api-error": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.1.tgz",
-            "integrity": "sha512-y1lGmfm38djrScwpeL37rRR9f1D6sM8RhMpvM7CYLzOlHVboouZokXK/G88BpzW0NQBSvCCOnW5BFhten4FPfA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
+            "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
             "dev": true
         },
         "node_modules/@webassemblyjs/helper-buffer": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.1.tgz",
-            "integrity": "sha512-uS6VSgieHbk/m4GSkMU5cqe/5TekdCzQso4revCIEQ3vpGZgqSSExi4jWpTWwDpAHOIAb1Jfrs0gUB9AA4n71w==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
+            "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
             "dev": true
         },
-        "node_modules/@webassemblyjs/helper-code-frame": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.1.tgz",
-            "integrity": "sha512-ZQ2ZT6Evk4DPIfD+92AraGYaFIqGm4U20e7FpXwl7WUo2Pn1mZ1v8VGH8i+Y++IQpxPbQo/UyG0Khs7eInskzA==",
+        "node_modules/@webassemblyjs/helper-numbers": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
+            "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
             "dev": true,
             "dependencies": {
-                "@webassemblyjs/wast-printer": "1.9.1"
-            }
-        },
-        "node_modules/@webassemblyjs/helper-fsm": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.1.tgz",
-            "integrity": "sha512-J32HGpveEqqcKFS0YbgicB0zAlpfIxJa5MjxDxhu3i5ltPcVfY5EPvKQ1suRguFPehxiUs+/hfkwPEXom/l0lw==",
-            "dev": true
-        },
-        "node_modules/@webassemblyjs/helper-module-context": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.1.tgz",
-            "integrity": "sha512-IEH2cMmEQKt7fqelLWB5e/cMdZXf2rST1JIrzWmf4XBt3QTxGdnnLvV4DYoN8pJjOx0VYXsWg+yF16MmJtolZg==",
-            "dev": true,
-            "dependencies": {
-                "@webassemblyjs/ast": "1.9.1"
+                "@webassemblyjs/floating-point-hex-parser": "1.11.1",
+                "@webassemblyjs/helper-api-error": "1.11.1",
+                "@xtuc/long": "4.2.2"
             }
         },
         "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.1.tgz",
-            "integrity": "sha512-i2rGTBqFUcSXxyjt2K4vm/3kkHwyzG6o427iCjcIKjOqpWH8SEem+xe82jUk1iydJO250/CvE5o7hzNAMZf0dQ==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
+            "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
             "dev": true
         },
         "node_modules/@webassemblyjs/helper-wasm-section": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.1.tgz",
-            "integrity": "sha512-FetqzjtXZr2d57IECK+aId3D0IcGweeM0CbAnJHkYJkcRTHP+YcMb7Wmc0j21h5UWBpwYGb9dSkK/93SRCTrGg==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
+            "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
             "dev": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.9.1",
-                "@webassemblyjs/helper-buffer": "1.9.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.9.1",
-                "@webassemblyjs/wasm-gen": "1.9.1"
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1"
             }
         },
         "node_modules/@webassemblyjs/ieee754": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.9.1.tgz",
-            "integrity": "sha512-EvTG9M78zP1MmkBpUjGQHZc26DzPGZSLIPxYHCjQsBMo60Qy2W34qf8z0exRDtxBbRIoiKa5dFyWer/7r1aaSQ==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
+            "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
             "dev": true,
             "dependencies": {
                 "@xtuc/ieee754": "^1.2.0"
             }
         },
         "node_modules/@webassemblyjs/leb128": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.9.1.tgz",
-            "integrity": "sha512-Oc04ub0vFfLnF+2/+ki3AE+anmW4sv9uNBqb+79fgTaPv6xJsOT0dhphNfL3FrME84CbX/D1T9XT8tjFo0IIiw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
+            "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
             "dev": true,
             "dependencies": {
                 "@xtuc/long": "4.2.2"
             }
         },
         "node_modules/@webassemblyjs/utf8": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.9.1.tgz",
-            "integrity": "sha512-llkYtppagjCodFjo0alWOUhAkfOiQPQDIc5oA6C9sFAXz7vC9QhZf/f8ijQIX+A9ToM3c9Pq85X0EX7nx9gVhg==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
+            "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
             "dev": true
         },
         "node_modules/@webassemblyjs/wasm-edit": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.1.tgz",
-            "integrity": "sha512-S2IaD6+x9B2Xi8BCT0eGsrXXd8UxAh2LVJpg1ZMtHXnrDcsTtIX2bDjHi40Hio6Lc62dWHmKdvksI+MClCYbbw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
+            "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
             "dev": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.9.1",
-                "@webassemblyjs/helper-buffer": "1.9.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.9.1",
-                "@webassemblyjs/helper-wasm-section": "1.9.1",
-                "@webassemblyjs/wasm-gen": "1.9.1",
-                "@webassemblyjs/wasm-opt": "1.9.1",
-                "@webassemblyjs/wasm-parser": "1.9.1",
-                "@webassemblyjs/wast-printer": "1.9.1"
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/helper-wasm-section": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1",
+                "@webassemblyjs/wasm-opt": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1",
+                "@webassemblyjs/wast-printer": "1.11.1"
             }
         },
         "node_modules/@webassemblyjs/wasm-gen": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.1.tgz",
-            "integrity": "sha512-bqWI0S4lBQsEN5FTZ35vYzfKUJvtjNnBobB1agCALH30xNk1LToZ7Z8eiaR/Z5iVECTlBndoRQV3F6mbEqE/fg==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
+            "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
             "dev": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.9.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.9.1",
-                "@webassemblyjs/ieee754": "1.9.1",
-                "@webassemblyjs/leb128": "1.9.1",
-                "@webassemblyjs/utf8": "1.9.1"
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/ieee754": "1.11.1",
+                "@webassemblyjs/leb128": "1.11.1",
+                "@webassemblyjs/utf8": "1.11.1"
             }
         },
         "node_modules/@webassemblyjs/wasm-opt": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.1.tgz",
-            "integrity": "sha512-gSf7I7YWVXZ5c6XqTEqkZjVs8K1kc1k57vsB6KBQscSagDNbAdxt6MwuJoMjsE1yWY1tsuL+pga268A6u+Fdkg==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
+            "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
             "dev": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.9.1",
-                "@webassemblyjs/helper-buffer": "1.9.1",
-                "@webassemblyjs/wasm-gen": "1.9.1",
-                "@webassemblyjs/wasm-parser": "1.9.1"
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1"
             }
         },
         "node_modules/@webassemblyjs/wasm-parser": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.1.tgz",
-            "integrity": "sha512-ImM4N2T1MEIond0MyE3rXvStVxEmivQrDKf/ggfh5pP6EHu3lL/YTAoSrR7shrbKNPpeKpGesW1LIK/L4kqduw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
+            "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
             "dev": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.9.1",
-                "@webassemblyjs/helper-api-error": "1.9.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.9.1",
-                "@webassemblyjs/ieee754": "1.9.1",
-                "@webassemblyjs/leb128": "1.9.1",
-                "@webassemblyjs/utf8": "1.9.1"
-            }
-        },
-        "node_modules/@webassemblyjs/wast-parser": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.9.1.tgz",
-            "integrity": "sha512-2xVxejXSvj3ls/o2TR/zI6p28qsGupjHhnHL6URULQRcXmryn3w7G83jQMcT7PHqUfyle65fZtWLukfdLdE7qw==",
-            "dev": true,
-            "dependencies": {
-                "@webassemblyjs/ast": "1.9.1",
-                "@webassemblyjs/floating-point-hex-parser": "1.9.1",
-                "@webassemblyjs/helper-api-error": "1.9.1",
-                "@webassemblyjs/helper-code-frame": "1.9.1",
-                "@webassemblyjs/helper-fsm": "1.9.1",
-                "@xtuc/long": "4.2.2"
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-api-error": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/ieee754": "1.11.1",
+                "@webassemblyjs/leb128": "1.11.1",
+                "@webassemblyjs/utf8": "1.11.1"
             }
         },
         "node_modules/@webassemblyjs/wast-printer": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.9.1.tgz",
-            "integrity": "sha512-tDV8V15wm7mmbAH6XvQRU1X+oPGmeOzYsd6h7hlRLz6QpV4Ec/KKxM8OpLtFmQPLCreGxTp+HuxtH4pRIZyL9w==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
+            "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
             "dev": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.9.1",
-                "@webassemblyjs/wast-parser": "1.9.1",
+                "@webassemblyjs/ast": "1.11.1",
                 "@xtuc/long": "4.2.2"
             }
         },
-        "node_modules/@webpack-cli/info": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.2.1.tgz",
-            "integrity": "sha512-fLnDML5HZ5AEKzHul8xLAksoKN2cibu6MgonkUj8R9V7bbeVRkd1XbGEGWrAUNYHbX1jcqCsDEpBviE5StPMzQ==",
+        "node_modules/@webpack-cli/configtest": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.0.1.tgz",
+            "integrity": "sha512-njsdJXJSiS2iNbQVS0eT8A/KPnmyH4pv1APj2K0d1wrZcBLw+yppxOy4CGqa0OxDJkzfL/XELDhD8rocnIwB5A==",
             "dev": true,
-            "dependencies": {
-                "envinfo": "^7.7.3"
+            "engines": {
+                "node": ">=14.15.0"
             },
             "peerDependencies": {
-                "webpack-cli": "4.x.x"
+                "webpack": "5.x.x",
+                "webpack-cli": "5.x.x"
+            }
+        },
+        "node_modules/@webpack-cli/info": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.1.tgz",
+            "integrity": "sha512-fE1UEWTwsAxRhrJNikE7v4EotYflkEhBL7EbajfkPlf6E37/2QshOy/D48Mw8G5XMFlQtS6YV42vtbG9zBpIQA==",
+            "dev": true,
+            "engines": {
+                "node": ">=14.15.0"
+            },
+            "peerDependencies": {
+                "webpack": "5.x.x",
+                "webpack-cli": "5.x.x"
             }
         },
         "node_modules/@webpack-cli/serve": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.2.1.tgz",
-            "integrity": "sha512-Zj1z6AyS+vqV6Hfi7ngCjFGdHV5EwZNIHo6QfFTNe9PyW+zBU1zJ9BiOW1pmUEq950RC4+Dym6flyA/61/vhyw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.1.tgz",
+            "integrity": "sha512-0G7tNyS+yW8TdgHwZKlDWYXFA6OJQnoLCQvYKkQP0Q2X205PSQ6RNUj0M+1OB/9gRQaUZ/ccYfaxd0nhaWKfjw==",
             "dev": true,
+            "engines": {
+                "node": ">=14.15.0"
+            },
             "peerDependencies": {
-                "webpack-cli": "4.x.x"
+                "webpack": "5.x.x",
+                "webpack-cli": "5.x.x"
             },
             "peerDependenciesMeta": {
                 "webpack-dev-server": {
@@ -351,15 +340,24 @@
             "dev": true
         },
         "node_modules/acorn": {
-            "version": "8.7.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-            "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+            "version": "8.8.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+            "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
             "engines": {
                 "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-import-assertions": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+            "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+            "dev": true,
+            "peerDependencies": {
+                "acorn": "^8"
             }
         },
         "node_modules/ajv": {
@@ -650,6 +648,20 @@
                 "wrap-ansi": "^7.0.0"
             }
         },
+        "node_modules/clone-deep": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+            "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+            "dev": true,
+            "dependencies": {
+                "is-plain-object": "^2.0.4",
+                "kind-of": "^6.0.2",
+                "shallow-clone": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -669,9 +681,9 @@
             "dev": true
         },
         "node_modules/colorette": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
-            "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+            "version": "2.0.19",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+            "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
             "dev": true
         },
         "node_modules/commander": {
@@ -750,9 +762,9 @@
             "dev": true
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.4.1",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.4.1.tgz",
-            "integrity": "sha512-4GbyIMzYktTFoRSmkbgZ1LU+RXwf4AQ8Z+rSuuh1dC8plp0PPeaWvx6+G4hh4KnUJ48VoxKbNyA1QQQIUpXjYA==",
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz",
+            "integrity": "sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==",
             "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.2.4",
@@ -762,22 +774,10 @@
                 "node": ">=10.13.0"
             }
         },
-        "node_modules/enquirer": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-            "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-            "dev": true,
-            "dependencies": {
-                "ansi-colors": "^4.1.1"
-            },
-            "engines": {
-                "node": ">=8.6"
-            }
-        },
         "node_modules/envinfo": {
-            "version": "7.7.3",
-            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.7.3.tgz",
-            "integrity": "sha512-46+j5QxbPWza0PB1i15nZx0xQ4I/EfQxg9J8Had3b408SV63nEtor2e+oiY63amTo9KTuh2a3XLObNwduxYwwA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
+            "integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
             "dev": true,
             "bin": {
                 "envinfo": "dist/cli.js"
@@ -785,6 +785,12 @@
             "engines": {
                 "node": ">=4"
             }
+        },
+        "node_modules/es-module-lexer": {
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+            "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+            "dev": true
         },
         "node_modules/escalade": {
             "version": "3.1.1",
@@ -845,29 +851,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.8.x"
-            }
-        },
-        "node_modules/execa": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
-            "integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
-            "dev": true,
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.0",
-                "human-signals": "^2.1.0",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.1",
-                "onetime": "^5.1.2",
-                "signal-exit": "^3.0.3",
-                "strip-final-newline": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
             }
         },
         "node_modules/fast-deep-equal": {
@@ -951,18 +934,6 @@
                 "node": "*"
             }
         },
-        "node_modules/get-stream": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
-            "integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/glob": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -1000,9 +971,9 @@
             "dev": true
         },
         "node_modules/graceful-fs": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-            "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+            "version": "4.2.10",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
             "dev": true
         },
         "node_modules/has": {
@@ -1033,15 +1004,6 @@
             "dev": true,
             "bin": {
                 "he": "bin/he"
-            }
-        },
-        "node_modules/human-signals": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-            "dev": true,
-            "engines": {
-                "node": ">=10.17.0"
             }
         },
         "node_modules/import-local": {
@@ -1133,12 +1095,12 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "node_modules/interpret": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
-            "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+            "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
             "dev": true,
             "engines": {
-                "node": ">= 0.10"
+                "node": ">=10.13.0"
             }
         },
         "node_modules/is-binary-path": {
@@ -1154,9 +1116,9 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-            "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+            "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
             "dev": true,
             "dependencies": {
                 "has": "^1.0.3"
@@ -1211,13 +1173,16 @@
                 "node": ">=8"
             }
         },
-        "node_modules/is-stream": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-            "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+        "node_modules/is-plain-object": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
+            "dependencies": {
+                "isobject": "^3.0.1"
+            },
             "engines": {
-                "node": ">=8"
+                "node": ">=0.10.0"
             }
         },
         "node_modules/is-unicode-supported": {
@@ -1235,21 +1200,45 @@
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true
         },
+        "node_modules/isobject": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+            "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/jest-worker": {
-            "version": "26.6.2",
-            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
-            "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+            "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*",
                 "merge-stream": "^2.0.0",
-                "supports-color": "^7.0.0"
+                "supports-color": "^8.0.0"
             },
             "engines": {
                 "node": ">= 10.13.0"
+            }
+        },
+        "node_modules/jest-worker/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
         "node_modules/js-yaml": {
@@ -1264,10 +1253,10 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
-        "node_modules/json-parse-better-errors": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+        "node_modules/json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true
         },
         "node_modules/json-schema-traverse": {
@@ -1275,6 +1264,15 @@
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
+        },
+        "node_modules/kind-of": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/loader-runner": {
             "version": "4.2.0",
@@ -1284,12 +1282,6 @@
             "engines": {
                 "node": ">=6.11.5"
             }
-        },
-        "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "dev": true
         },
         "node_modules/log-symbols": {
             "version": "4.1.0",
@@ -1334,19 +1326,10 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -1498,15 +1481,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/mocha/node_modules/serialize-javascript": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-            "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
-            "dev": true,
-            "dependencies": {
-                "randombytes": "^2.1.0"
-            }
-        },
         "node_modules/mocha/node_modules/supports-color": {
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -1555,39 +1529,12 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/npm-run-path": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-            "dev": true,
-            "dependencies": {
-                "path-key": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dependencies": {
                 "wrappy": "1"
-            }
-        },
-        "node_modules/onetime": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dev": true,
-            "dependencies": {
-                "mimic-fn": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/p-limit": {
@@ -1658,88 +1605,6 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
-        "node_modules/pkg-dir": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
-            "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
-            "dev": true,
-            "dependencies": {
-                "find-up": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/pkg-dir/node_modules/find-up": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-            "dev": true,
-            "dependencies": {
-                "locate-path": "^6.0.0",
-                "path-exists": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/pkg-dir/node_modules/locate-path": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-            "dev": true,
-            "dependencies": {
-                "p-locate": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/pkg-dir/node_modules/p-limit": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-            "dev": true,
-            "dependencies": {
-                "yocto-queue": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/pkg-dir/node_modules/p-locate": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-            "dev": true,
-            "dependencies": {
-                "p-limit": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/pkg-dir/node_modules/path-exists": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -1771,15 +1636,15 @@
             }
         },
         "node_modules/rechoir": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.0.tgz",
-            "integrity": "sha512-ADsDEH2bvbjltXEP+hTIAmeFekTFK0V2BTxMkok6qILyAJEXV0AFfoWcAq4yfll5VdIMd/RVXq0lR+wQi5ZU3Q==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+            "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
             "dev": true,
             "dependencies": {
-                "resolve": "^1.9.0"
+                "resolve": "^1.20.0"
             },
             "engines": {
-                "node": ">= 0.10"
+                "node": ">= 10.13.0"
             }
         },
         "node_modules/require-directory": {
@@ -1792,13 +1657,17 @@
             }
         },
         "node_modules/resolve": {
-            "version": "1.19.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-            "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+            "version": "1.22.1",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+            "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
             "dev": true,
             "dependencies": {
-                "is-core-module": "^2.1.0",
-                "path-parse": "^1.0.6"
+                "is-core-module": "^2.9.0",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -1847,12 +1716,12 @@
             "dev": true
         },
         "node_modules/schema-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
-            "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+            "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
             "dev": true,
             "dependencies": {
-                "@types/json-schema": "^7.0.6",
+                "@types/json-schema": "^7.0.8",
                 "ajv": "^6.12.5",
                 "ajv-keywords": "^3.5.2"
             },
@@ -1865,12 +1734,24 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
-            "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+            "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
             "dev": true,
             "dependencies": {
                 "randombytes": "^2.1.0"
+            }
+        },
+        "node_modules/shallow-clone": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+            "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+            "dev": true,
+            "dependencies": {
+                "kind-of": "^6.0.2"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/shebang-command": {
@@ -1893,18 +1774,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/signal-exit": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-            "dev": true
-        },
-        "node_modules/source-list-map": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
-            "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
-            "dev": true
         },
         "node_modules/source-map": {
             "version": "0.6.1",
@@ -1951,15 +1820,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/strip-final-newline": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -1984,19 +1844,31 @@
                 "node": ">=8"
             }
         },
+        "node_modules/supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/tapable": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz",
-            "integrity": "sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+            "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
             "dev": true,
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/terser": {
-            "version": "5.14.2",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-            "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
+            "version": "5.16.1",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
+            "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.2",
@@ -2012,17 +1884,16 @@
             }
         },
         "node_modules/terser-webpack-plugin": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.0.3.tgz",
-            "integrity": "sha512-zFdGk8Lh9ZJGPxxPE6jwysOlATWB8GMW8HcfGULWA/nPal+3VdATflQvSBSLQJRCmYZnfFJl6vkRTiwJGNgPiQ==",
+            "version": "5.3.6",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
+            "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
             "dev": true,
             "dependencies": {
-                "jest-worker": "^26.6.1",
-                "p-limit": "^3.0.2",
-                "schema-utils": "^3.0.0",
-                "serialize-javascript": "^5.0.1",
-                "source-map": "^0.6.1",
-                "terser": "^5.3.8"
+                "@jridgewell/trace-mapping": "^0.3.14",
+                "jest-worker": "^27.4.5",
+                "schema-utils": "^3.1.1",
+                "serialize-javascript": "^6.0.0",
+                "terser": "^5.14.1"
             },
             "engines": {
                 "node": ">= 10.13.0"
@@ -2033,21 +1904,17 @@
             },
             "peerDependencies": {
                 "webpack": "^5.1.0"
-            }
-        },
-        "node_modules/terser-webpack-plugin/node_modules/p-limit": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-            "dev": true,
-            "dependencies": {
-                "yocto-queue": "^0.1.0"
             },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+            "peerDependenciesMeta": {
+                "@swc/core": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "uglify-js": {
+                    "optional": true
+                }
             }
         },
         "node_modules/to-regex-range": {
@@ -2078,24 +1945,18 @@
             }
         },
         "node_modules/uri-js": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-            "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dev": true,
             "dependencies": {
                 "punycode": "^2.1.0"
             }
         },
-        "node_modules/v8-compile-cache": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
-            "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
-            "dev": true
-        },
         "node_modules/watchpack": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.1.0.tgz",
-            "integrity": "sha512-UjgD1mqjkG99+3lgG36at4wPnUXNvis2v1utwTgQ43C22c4LD71LsYMExdWXh4HZ+RmW+B0t1Vrg2GpXAkTOQw==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+            "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
             "dev": true,
             "dependencies": {
                 "glob-to-regexp": "^0.4.1",
@@ -2106,35 +1967,35 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.11.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.11.1.tgz",
-            "integrity": "sha512-tNUIdAmYJv+nupRs/U/gqmADm6fgrf5xE+rSlSsf2PgsGO7j2WG7ccU6AWNlOJlHFl+HnmXlBmHIkiLf+XA9mQ==",
+            "version": "5.75.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
+            "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
             "dev": true,
             "dependencies": {
-                "@types/eslint-scope": "^3.7.0",
-                "@types/estree": "^0.0.45",
-                "@webassemblyjs/ast": "1.9.1",
-                "@webassemblyjs/helper-module-context": "1.9.1",
-                "@webassemblyjs/wasm-edit": "1.9.1",
-                "@webassemblyjs/wasm-parser": "1.9.1",
-                "acorn": "^8.0.4",
+                "@types/eslint-scope": "^3.7.3",
+                "@types/estree": "^0.0.51",
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/wasm-edit": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1",
+                "acorn": "^8.7.1",
+                "acorn-import-assertions": "^1.7.6",
                 "browserslist": "^4.14.5",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.3.1",
-                "eslint-scope": "^5.1.1",
+                "enhanced-resolve": "^5.10.0",
+                "es-module-lexer": "^0.9.0",
+                "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
                 "glob-to-regexp": "^0.4.1",
-                "graceful-fs": "^4.2.4",
-                "json-parse-better-errors": "^1.0.2",
-                "loader-runner": "^4.1.0",
+                "graceful-fs": "^4.2.9",
+                "json-parse-even-better-errors": "^2.3.1",
+                "loader-runner": "^4.2.0",
                 "mime-types": "^2.1.27",
                 "neo-async": "^2.6.2",
-                "pkg-dir": "^5.0.0",
-                "schema-utils": "^3.0.0",
+                "schema-utils": "^3.1.0",
                 "tapable": "^2.1.1",
-                "terser-webpack-plugin": "^5.0.3",
-                "watchpack": "^2.0.0",
-                "webpack-sources": "^2.1.1"
+                "terser-webpack-plugin": "^5.1.3",
+                "watchpack": "^2.4.0",
+                "webpack-sources": "^3.2.3"
             },
             "bin": {
                 "webpack": "bin/webpack.js"
@@ -2153,42 +2014,40 @@
             }
         },
         "node_modules/webpack-cli": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.3.1.tgz",
-            "integrity": "sha512-/F4+9QNZM/qKzzL9/06Am8NXIkGV+/NqQ62Dx7DSqudxxpAgBqYn6V7+zp+0Y7JuWksKUbczRY3wMTd+7Uj6OA==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.0.1.tgz",
+            "integrity": "sha512-S3KVAyfwUqr0Mo/ur3NzIp6jnerNpo7GUO6so51mxLi1spqsA17YcMXy0WOIJtBSnj748lthxC6XLbNKh/ZC+A==",
             "dev": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
-                "@webpack-cli/info": "^1.2.1",
-                "@webpack-cli/serve": "^1.2.1",
-                "colorette": "^1.2.1",
-                "commander": "^6.2.0",
-                "enquirer": "^2.3.6",
-                "execa": "^5.0.0",
+                "@webpack-cli/configtest": "^2.0.1",
+                "@webpack-cli/info": "^2.0.1",
+                "@webpack-cli/serve": "^2.0.1",
+                "colorette": "^2.0.14",
+                "commander": "^9.4.1",
+                "cross-spawn": "^7.0.3",
+                "envinfo": "^7.7.3",
                 "fastest-levenshtein": "^1.0.12",
                 "import-local": "^3.0.2",
-                "interpret": "^2.2.0",
-                "rechoir": "^0.7.0",
-                "v8-compile-cache": "^2.2.0",
-                "webpack-merge": "^4.2.2"
+                "interpret": "^3.1.1",
+                "rechoir": "^0.8.0",
+                "webpack-merge": "^5.7.3"
             },
             "bin": {
                 "webpack-cli": "bin/cli.js"
             },
             "engines": {
-                "node": ">=10.13.0"
+                "node": ">=14.15.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "4.x.x || 5.x.x"
+                "webpack": "5.x.x"
             },
             "peerDependenciesMeta": {
                 "@webpack-cli/generators": {
-                    "optional": true
-                },
-                "@webpack-cli/init": {
-                    "optional": true
-                },
-                "@webpack-cli/migrate": {
                     "optional": true
                 },
                 "webpack-bundle-analyzer": {
@@ -2200,32 +2059,32 @@
             }
         },
         "node_modules/webpack-cli/node_modules/commander": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-            "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
+            "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
             "dev": true,
             "engines": {
-                "node": ">= 6"
+                "node": "^12.20.0 || >=14"
             }
         },
         "node_modules/webpack-merge": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
-            "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
+            "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
             "dev": true,
             "dependencies": {
-                "lodash": "^4.17.15"
+                "clone-deep": "^4.0.1",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/webpack-sources": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.2.0.tgz",
-            "integrity": "sha512-bQsA24JLwcnWGArOKUxYKhX3Mz/nK1Xf6hxullKERyktjNMC4x8koOeaDNTA2fEJ09BdWLbM/iTW0ithREUP0w==",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+            "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
             "dev": true,
-            "dependencies": {
-                "source-list-map": "^2.0.1",
-                "source-map": "^0.6.1"
-            },
             "engines": {
                 "node": ">=10.13.0"
             }
@@ -2244,6 +2103,12 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/wildcard": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
+            "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
+            "dev": true
         },
         "node_modules/workerpool": {
             "version": "6.2.1",
@@ -2408,19 +2273,19 @@
             "dev": true
         },
         "@jridgewell/trace-mapping": {
-            "version": "0.3.14",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
-            "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+            "version": "0.3.17",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+            "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
             "dev": true,
             "requires": {
-                "@jridgewell/resolve-uri": "^3.0.3",
-                "@jridgewell/sourcemap-codec": "^1.4.10"
+                "@jridgewell/resolve-uri": "3.1.0",
+                "@jridgewell/sourcemap-codec": "1.4.14"
             }
         },
         "@types/eslint": {
-            "version": "7.2.6",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.6.tgz",
-            "integrity": "sha512-I+1sYH+NPQ3/tVqCeUSBwTE/0heyvtXqpIopUUArlBm0Kpocb8FbMa3AZ/ASKIFpN3rnEx932TTXDbt9OXsNDw==",
+            "version": "8.4.10",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.10.tgz",
+            "integrity": "sha512-Sl/HOqN8NKPmhWo2VBEPm0nvHnu2LL3v9vKo8MEq0EtbJ4eVzGPl41VNPvn5E1i5poMk4/XD8UriLHpJvEP/Nw==",
             "dev": true,
             "requires": {
                 "@types/estree": "*",
@@ -2428,9 +2293,9 @@
             }
         },
         "@types/eslint-scope": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.0.tgz",
-            "integrity": "sha512-O/ql2+rrCUe2W2rs7wMR+GqPRcgB6UiqN5RhrR5xruFlY7l9YLMn0ZkDzjoHLeiFkR8MCQZVudUuuvQ2BLC9Qw==",
+            "version": "3.7.4",
+            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
+            "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
             "dev": true,
             "requires": {
                 "@types/eslint": "*",
@@ -2438,21 +2303,21 @@
             }
         },
         "@types/estree": {
-            "version": "0.0.45",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.45.tgz",
-            "integrity": "sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==",
+            "version": "0.0.51",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+            "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
             "dev": true
         },
         "@types/json-schema": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
-            "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+            "version": "7.0.11",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+            "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
             "dev": true
         },
         "@types/node": {
-            "version": "14.14.20",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.20.tgz",
-            "integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A==",
+            "version": "18.11.15",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.15.tgz",
+            "integrity": "sha512-VkhBbVo2+2oozlkdHXLrb3zjsRkpdnaU2bXmX8Wgle3PUi569eLRaHGlgETQHR7lLL1w7GiG3h9SnePhxNDecw==",
             "dev": true
         },
         "@ungap/promise-all-settled": {
@@ -2462,193 +2327,169 @@
             "dev": true
         },
         "@webassemblyjs/ast": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.1.tgz",
-            "integrity": "sha512-uMu1nCWn2Wxyy126LlGqRVlhdTOsO/bsBRI4dNq3+6SiSuRKRQX6ejjKgh82LoGAPSq72lDUiQ4FWVaf0PecYw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
+            "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/helper-module-context": "1.9.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.9.1",
-                "@webassemblyjs/wast-parser": "1.9.1"
+                "@webassemblyjs/helper-numbers": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
             }
         },
         "@webassemblyjs/floating-point-hex-parser": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.1.tgz",
-            "integrity": "sha512-5VEKu024RySmLKTTBl9q1eO/2K5jk9ZS+2HXDBLA9s9p5IjkaXxWiDb/+b7wSQp6FRdLaH1IVGIfOex58Na2pg==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
+            "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
             "dev": true
         },
         "@webassemblyjs/helper-api-error": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.1.tgz",
-            "integrity": "sha512-y1lGmfm38djrScwpeL37rRR9f1D6sM8RhMpvM7CYLzOlHVboouZokXK/G88BpzW0NQBSvCCOnW5BFhten4FPfA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
+            "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
             "dev": true
         },
         "@webassemblyjs/helper-buffer": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.1.tgz",
-            "integrity": "sha512-uS6VSgieHbk/m4GSkMU5cqe/5TekdCzQso4revCIEQ3vpGZgqSSExi4jWpTWwDpAHOIAb1Jfrs0gUB9AA4n71w==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
+            "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
             "dev": true
         },
-        "@webassemblyjs/helper-code-frame": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.1.tgz",
-            "integrity": "sha512-ZQ2ZT6Evk4DPIfD+92AraGYaFIqGm4U20e7FpXwl7WUo2Pn1mZ1v8VGH8i+Y++IQpxPbQo/UyG0Khs7eInskzA==",
+        "@webassemblyjs/helper-numbers": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
+            "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/wast-printer": "1.9.1"
-            }
-        },
-        "@webassemblyjs/helper-fsm": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.1.tgz",
-            "integrity": "sha512-J32HGpveEqqcKFS0YbgicB0zAlpfIxJa5MjxDxhu3i5ltPcVfY5EPvKQ1suRguFPehxiUs+/hfkwPEXom/l0lw==",
-            "dev": true
-        },
-        "@webassemblyjs/helper-module-context": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.1.tgz",
-            "integrity": "sha512-IEH2cMmEQKt7fqelLWB5e/cMdZXf2rST1JIrzWmf4XBt3QTxGdnnLvV4DYoN8pJjOx0VYXsWg+yF16MmJtolZg==",
-            "dev": true,
-            "requires": {
-                "@webassemblyjs/ast": "1.9.1"
+                "@webassemblyjs/floating-point-hex-parser": "1.11.1",
+                "@webassemblyjs/helper-api-error": "1.11.1",
+                "@xtuc/long": "4.2.2"
             }
         },
         "@webassemblyjs/helper-wasm-bytecode": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.1.tgz",
-            "integrity": "sha512-i2rGTBqFUcSXxyjt2K4vm/3kkHwyzG6o427iCjcIKjOqpWH8SEem+xe82jUk1iydJO250/CvE5o7hzNAMZf0dQ==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
+            "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
             "dev": true
         },
         "@webassemblyjs/helper-wasm-section": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.1.tgz",
-            "integrity": "sha512-FetqzjtXZr2d57IECK+aId3D0IcGweeM0CbAnJHkYJkcRTHP+YcMb7Wmc0j21h5UWBpwYGb9dSkK/93SRCTrGg==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
+            "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.9.1",
-                "@webassemblyjs/helper-buffer": "1.9.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.9.1",
-                "@webassemblyjs/wasm-gen": "1.9.1"
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1"
             }
         },
         "@webassemblyjs/ieee754": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.9.1.tgz",
-            "integrity": "sha512-EvTG9M78zP1MmkBpUjGQHZc26DzPGZSLIPxYHCjQsBMo60Qy2W34qf8z0exRDtxBbRIoiKa5dFyWer/7r1aaSQ==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
+            "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
             "dev": true,
             "requires": {
                 "@xtuc/ieee754": "^1.2.0"
             }
         },
         "@webassemblyjs/leb128": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.9.1.tgz",
-            "integrity": "sha512-Oc04ub0vFfLnF+2/+ki3AE+anmW4sv9uNBqb+79fgTaPv6xJsOT0dhphNfL3FrME84CbX/D1T9XT8tjFo0IIiw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
+            "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
             "dev": true,
             "requires": {
                 "@xtuc/long": "4.2.2"
             }
         },
         "@webassemblyjs/utf8": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.9.1.tgz",
-            "integrity": "sha512-llkYtppagjCodFjo0alWOUhAkfOiQPQDIc5oA6C9sFAXz7vC9QhZf/f8ijQIX+A9ToM3c9Pq85X0EX7nx9gVhg==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
+            "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
             "dev": true
         },
         "@webassemblyjs/wasm-edit": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.1.tgz",
-            "integrity": "sha512-S2IaD6+x9B2Xi8BCT0eGsrXXd8UxAh2LVJpg1ZMtHXnrDcsTtIX2bDjHi40Hio6Lc62dWHmKdvksI+MClCYbbw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
+            "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.9.1",
-                "@webassemblyjs/helper-buffer": "1.9.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.9.1",
-                "@webassemblyjs/helper-wasm-section": "1.9.1",
-                "@webassemblyjs/wasm-gen": "1.9.1",
-                "@webassemblyjs/wasm-opt": "1.9.1",
-                "@webassemblyjs/wasm-parser": "1.9.1",
-                "@webassemblyjs/wast-printer": "1.9.1"
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/helper-wasm-section": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1",
+                "@webassemblyjs/wasm-opt": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1",
+                "@webassemblyjs/wast-printer": "1.11.1"
             }
         },
         "@webassemblyjs/wasm-gen": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.1.tgz",
-            "integrity": "sha512-bqWI0S4lBQsEN5FTZ35vYzfKUJvtjNnBobB1agCALH30xNk1LToZ7Z8eiaR/Z5iVECTlBndoRQV3F6mbEqE/fg==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
+            "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.9.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.9.1",
-                "@webassemblyjs/ieee754": "1.9.1",
-                "@webassemblyjs/leb128": "1.9.1",
-                "@webassemblyjs/utf8": "1.9.1"
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/ieee754": "1.11.1",
+                "@webassemblyjs/leb128": "1.11.1",
+                "@webassemblyjs/utf8": "1.11.1"
             }
         },
         "@webassemblyjs/wasm-opt": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.1.tgz",
-            "integrity": "sha512-gSf7I7YWVXZ5c6XqTEqkZjVs8K1kc1k57vsB6KBQscSagDNbAdxt6MwuJoMjsE1yWY1tsuL+pga268A6u+Fdkg==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
+            "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.9.1",
-                "@webassemblyjs/helper-buffer": "1.9.1",
-                "@webassemblyjs/wasm-gen": "1.9.1",
-                "@webassemblyjs/wasm-parser": "1.9.1"
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1"
             }
         },
         "@webassemblyjs/wasm-parser": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.1.tgz",
-            "integrity": "sha512-ImM4N2T1MEIond0MyE3rXvStVxEmivQrDKf/ggfh5pP6EHu3lL/YTAoSrR7shrbKNPpeKpGesW1LIK/L4kqduw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
+            "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.9.1",
-                "@webassemblyjs/helper-api-error": "1.9.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.9.1",
-                "@webassemblyjs/ieee754": "1.9.1",
-                "@webassemblyjs/leb128": "1.9.1",
-                "@webassemblyjs/utf8": "1.9.1"
-            }
-        },
-        "@webassemblyjs/wast-parser": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.9.1.tgz",
-            "integrity": "sha512-2xVxejXSvj3ls/o2TR/zI6p28qsGupjHhnHL6URULQRcXmryn3w7G83jQMcT7PHqUfyle65fZtWLukfdLdE7qw==",
-            "dev": true,
-            "requires": {
-                "@webassemblyjs/ast": "1.9.1",
-                "@webassemblyjs/floating-point-hex-parser": "1.9.1",
-                "@webassemblyjs/helper-api-error": "1.9.1",
-                "@webassemblyjs/helper-code-frame": "1.9.1",
-                "@webassemblyjs/helper-fsm": "1.9.1",
-                "@xtuc/long": "4.2.2"
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-api-error": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/ieee754": "1.11.1",
+                "@webassemblyjs/leb128": "1.11.1",
+                "@webassemblyjs/utf8": "1.11.1"
             }
         },
         "@webassemblyjs/wast-printer": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.9.1.tgz",
-            "integrity": "sha512-tDV8V15wm7mmbAH6XvQRU1X+oPGmeOzYsd6h7hlRLz6QpV4Ec/KKxM8OpLtFmQPLCreGxTp+HuxtH4pRIZyL9w==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
+            "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.9.1",
-                "@webassemblyjs/wast-parser": "1.9.1",
+                "@webassemblyjs/ast": "1.11.1",
                 "@xtuc/long": "4.2.2"
             }
         },
-        "@webpack-cli/info": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.2.1.tgz",
-            "integrity": "sha512-fLnDML5HZ5AEKzHul8xLAksoKN2cibu6MgonkUj8R9V7bbeVRkd1XbGEGWrAUNYHbX1jcqCsDEpBviE5StPMzQ==",
+        "@webpack-cli/configtest": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.0.1.tgz",
+            "integrity": "sha512-njsdJXJSiS2iNbQVS0eT8A/KPnmyH4pv1APj2K0d1wrZcBLw+yppxOy4CGqa0OxDJkzfL/XELDhD8rocnIwB5A==",
             "dev": true,
-            "requires": {
-                "envinfo": "^7.7.3"
-            }
+            "requires": {}
+        },
+        "@webpack-cli/info": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.1.tgz",
+            "integrity": "sha512-fE1UEWTwsAxRhrJNikE7v4EotYflkEhBL7EbajfkPlf6E37/2QshOy/D48Mw8G5XMFlQtS6YV42vtbG9zBpIQA==",
+            "dev": true,
+            "requires": {}
         },
         "@webpack-cli/serve": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.2.1.tgz",
-            "integrity": "sha512-Zj1z6AyS+vqV6Hfi7ngCjFGdHV5EwZNIHo6QfFTNe9PyW+zBU1zJ9BiOW1pmUEq950RC4+Dym6flyA/61/vhyw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.1.tgz",
+            "integrity": "sha512-0G7tNyS+yW8TdgHwZKlDWYXFA6OJQnoLCQvYKkQP0Q2X205PSQ6RNUj0M+1OB/9gRQaUZ/ccYfaxd0nhaWKfjw==",
             "dev": true,
             "requires": {}
         },
@@ -2665,10 +2506,17 @@
             "dev": true
         },
         "acorn": {
-            "version": "8.7.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-            "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+            "version": "8.8.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+            "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
             "dev": true
+        },
+        "acorn-import-assertions": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+            "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+            "dev": true,
+            "requires": {}
         },
         "ajv": {
             "version": "6.12.6",
@@ -2889,6 +2737,17 @@
                 "wrap-ansi": "^7.0.0"
             }
         },
+        "clone-deep": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+            "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+            "dev": true,
+            "requires": {
+                "is-plain-object": "^2.0.4",
+                "kind-of": "^6.0.2",
+                "shallow-clone": "^3.0.0"
+            }
+        },
         "color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2905,9 +2764,9 @@
             "dev": true
         },
         "colorette": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
-            "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+            "version": "2.0.19",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+            "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
             "dev": true
         },
         "commander": {
@@ -2971,28 +2830,25 @@
             "dev": true
         },
         "enhanced-resolve": {
-            "version": "5.4.1",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.4.1.tgz",
-            "integrity": "sha512-4GbyIMzYktTFoRSmkbgZ1LU+RXwf4AQ8Z+rSuuh1dC8plp0PPeaWvx6+G4hh4KnUJ48VoxKbNyA1QQQIUpXjYA==",
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz",
+            "integrity": "sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.2.4",
                 "tapable": "^2.2.0"
             }
         },
-        "enquirer": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-            "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-            "dev": true,
-            "requires": {
-                "ansi-colors": "^4.1.1"
-            }
-        },
         "envinfo": {
-            "version": "7.7.3",
-            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.7.3.tgz",
-            "integrity": "sha512-46+j5QxbPWza0PB1i15nZx0xQ4I/EfQxg9J8Had3b408SV63nEtor2e+oiY63amTo9KTuh2a3XLObNwduxYwwA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
+            "integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
+            "dev": true
+        },
+        "es-module-lexer": {
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+            "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
             "dev": true
         },
         "escalade": {
@@ -3039,23 +2895,6 @@
             "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
             "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
             "dev": true
-        },
-        "execa": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
-            "integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
-            "dev": true,
-            "requires": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.0",
-                "human-signals": "^2.1.0",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.1",
-                "onetime": "^5.1.2",
-                "signal-exit": "^3.0.3",
-                "strip-final-newline": "^2.0.0"
-            }
         },
         "fast-deep-equal": {
             "version": "3.1.3",
@@ -3119,12 +2958,6 @@
             "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
             "dev": true
         },
-        "get-stream": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
-            "integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
-            "dev": true
-        },
         "glob": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -3153,9 +2986,9 @@
             "dev": true
         },
         "graceful-fs": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-            "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+            "version": "4.2.10",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
             "dev": true
         },
         "has": {
@@ -3177,12 +3010,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-            "dev": true
-        },
-        "human-signals": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
             "dev": true
         },
         "import-local": {
@@ -3255,9 +3082,9 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "interpret": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
-            "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+            "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
             "dev": true
         },
         "is-binary-path": {
@@ -3270,9 +3097,9 @@
             }
         },
         "is-core-module": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-            "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+            "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
             "dev": true,
             "requires": {
                 "has": "^1.0.3"
@@ -3309,11 +3136,14 @@
             "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
             "dev": true
         },
-        "is-stream": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-            "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-            "dev": true
+        "is-plain-object": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+            "dev": true,
+            "requires": {
+                "isobject": "^3.0.1"
+            }
         },
         "is-unicode-supported": {
             "version": "0.1.0",
@@ -3324,18 +3154,35 @@
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true
+        },
+        "isobject": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+            "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
             "dev": true
         },
         "jest-worker": {
-            "version": "26.6.2",
-            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
-            "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+            "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
             "dev": true,
             "requires": {
                 "@types/node": "*",
                 "merge-stream": "^2.0.0",
-                "supports-color": "^7.0.0"
+                "supports-color": "^8.0.0"
+            },
+            "dependencies": {
+                "supports-color": {
+                    "version": "8.1.1",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+                    "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
             }
         },
         "js-yaml": {
@@ -3347,10 +3194,10 @@
                 "argparse": "^2.0.1"
             }
         },
-        "json-parse-better-errors": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+        "json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true
         },
         "json-schema-traverse": {
@@ -3359,16 +3206,16 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
+        "kind-of": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+            "dev": true
+        },
         "loader-runner": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
             "integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==",
-            "dev": true
-        },
-        "lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
         "log-symbols": {
@@ -3402,16 +3249,10 @@
                 "mime-db": "1.45.0"
             }
         },
-        "mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true
-        },
         "minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -3513,15 +3354,6 @@
                     "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
                     "dev": true
                 },
-                "serialize-javascript": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-                    "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
-                    "dev": true,
-                    "requires": {
-                        "randombytes": "^2.1.0"
-                    }
-                },
                 "supports-color": {
                     "version": "8.1.1",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -3557,30 +3389,12 @@
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
             "dev": true
         },
-        "npm-run-path": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-            "dev": true,
-            "requires": {
-                "path-key": "^3.0.0"
-            }
-        },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
                 "wrappy": "1"
-            }
-        },
-        "onetime": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dev": true,
-            "requires": {
-                "mimic-fn": "^2.1.0"
             }
         },
         "p-limit": {
@@ -3627,60 +3441,6 @@
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
             "dev": true
         },
-        "pkg-dir": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
-            "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
-            "dev": true,
-            "requires": {
-                "find-up": "^5.0.0"
-            },
-            "dependencies": {
-                "find-up": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-                    "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^6.0.0",
-                        "path-exists": "^4.0.0"
-                    }
-                },
-                "locate-path": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-                    "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^5.0.0"
-                    }
-                },
-                "p-limit": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-                    "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-                    "dev": true,
-                    "requires": {
-                        "yocto-queue": "^0.1.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-                    "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^3.0.2"
-                    }
-                },
-                "path-exists": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-                    "dev": true
-                }
-            }
-        },
         "punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -3706,12 +3466,12 @@
             }
         },
         "rechoir": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.0.tgz",
-            "integrity": "sha512-ADsDEH2bvbjltXEP+hTIAmeFekTFK0V2BTxMkok6qILyAJEXV0AFfoWcAq4yfll5VdIMd/RVXq0lR+wQi5ZU3Q==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+            "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
             "dev": true,
             "requires": {
-                "resolve": "^1.9.0"
+                "resolve": "^1.20.0"
             }
         },
         "require-directory": {
@@ -3721,13 +3481,14 @@
             "dev": true
         },
         "resolve": {
-            "version": "1.19.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-            "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+            "version": "1.22.1",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+            "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
             "dev": true,
             "requires": {
-                "is-core-module": "^2.1.0",
-                "path-parse": "^1.0.6"
+                "is-core-module": "^2.9.0",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
             }
         },
         "resolve-cwd": {
@@ -3761,23 +3522,32 @@
             "dev": true
         },
         "schema-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
-            "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+            "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
             "dev": true,
             "requires": {
-                "@types/json-schema": "^7.0.6",
+                "@types/json-schema": "^7.0.8",
                 "ajv": "^6.12.5",
                 "ajv-keywords": "^3.5.2"
             }
         },
         "serialize-javascript": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
-            "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+            "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
             "dev": true,
             "requires": {
                 "randombytes": "^2.1.0"
+            }
+        },
+        "shallow-clone": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+            "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+            "dev": true,
+            "requires": {
+                "kind-of": "^6.0.2"
             }
         },
         "shebang-command": {
@@ -3793,18 +3563,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-            "dev": true
-        },
-        "signal-exit": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-            "dev": true
-        },
-        "source-list-map": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
-            "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
             "dev": true
         },
         "source-map": {
@@ -3843,12 +3601,6 @@
                 "ansi-regex": "^5.0.1"
             }
         },
-        "strip-final-newline": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-            "dev": true
-        },
         "strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3864,16 +3616,22 @@
                 "has-flag": "^4.0.0"
             }
         },
+        "supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true
+        },
         "tapable": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz",
-            "integrity": "sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+            "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
             "dev": true
         },
         "terser": {
-            "version": "5.14.2",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-            "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
+            "version": "5.16.1",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
+            "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
             "dev": true,
             "requires": {
                 "@jridgewell/source-map": "^0.3.2",
@@ -3883,28 +3641,16 @@
             }
         },
         "terser-webpack-plugin": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.0.3.tgz",
-            "integrity": "sha512-zFdGk8Lh9ZJGPxxPE6jwysOlATWB8GMW8HcfGULWA/nPal+3VdATflQvSBSLQJRCmYZnfFJl6vkRTiwJGNgPiQ==",
+            "version": "5.3.6",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
+            "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
             "dev": true,
             "requires": {
-                "jest-worker": "^26.6.1",
-                "p-limit": "^3.0.2",
-                "schema-utils": "^3.0.0",
-                "serialize-javascript": "^5.0.1",
-                "source-map": "^0.6.1",
-                "terser": "^5.3.8"
-            },
-            "dependencies": {
-                "p-limit": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-                    "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-                    "dev": true,
-                    "requires": {
-                        "yocto-queue": "^0.1.0"
-                    }
-                }
+                "@jridgewell/trace-mapping": "^0.3.14",
+                "jest-worker": "^27.4.5",
+                "schema-utils": "^3.1.1",
+                "serialize-javascript": "^6.0.0",
+                "terser": "^5.14.1"
             }
         },
         "to-regex-range": {
@@ -3929,24 +3675,18 @@
             "dev": true
         },
         "uri-js": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-            "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dev": true,
             "requires": {
                 "punycode": "^2.1.0"
             }
         },
-        "v8-compile-cache": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
-            "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
-            "dev": true
-        },
         "watchpack": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.1.0.tgz",
-            "integrity": "sha512-UjgD1mqjkG99+3lgG36at4wPnUXNvis2v1utwTgQ43C22c4LD71LsYMExdWXh4HZ+RmW+B0t1Vrg2GpXAkTOQw==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+            "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
             "dev": true,
             "requires": {
                 "glob-to-regexp": "^0.4.1",
@@ -3954,84 +3694,81 @@
             }
         },
         "webpack": {
-            "version": "5.11.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.11.1.tgz",
-            "integrity": "sha512-tNUIdAmYJv+nupRs/U/gqmADm6fgrf5xE+rSlSsf2PgsGO7j2WG7ccU6AWNlOJlHFl+HnmXlBmHIkiLf+XA9mQ==",
+            "version": "5.75.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
+            "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
             "dev": true,
             "requires": {
-                "@types/eslint-scope": "^3.7.0",
-                "@types/estree": "^0.0.45",
-                "@webassemblyjs/ast": "1.9.1",
-                "@webassemblyjs/helper-module-context": "1.9.1",
-                "@webassemblyjs/wasm-edit": "1.9.1",
-                "@webassemblyjs/wasm-parser": "1.9.1",
-                "acorn": "^8.0.4",
+                "@types/eslint-scope": "^3.7.3",
+                "@types/estree": "^0.0.51",
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/wasm-edit": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1",
+                "acorn": "^8.7.1",
+                "acorn-import-assertions": "^1.7.6",
                 "browserslist": "^4.14.5",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.3.1",
-                "eslint-scope": "^5.1.1",
+                "enhanced-resolve": "^5.10.0",
+                "es-module-lexer": "^0.9.0",
+                "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
                 "glob-to-regexp": "^0.4.1",
-                "graceful-fs": "^4.2.4",
-                "json-parse-better-errors": "^1.0.2",
-                "loader-runner": "^4.1.0",
+                "graceful-fs": "^4.2.9",
+                "json-parse-even-better-errors": "^2.3.1",
+                "loader-runner": "^4.2.0",
                 "mime-types": "^2.1.27",
                 "neo-async": "^2.6.2",
-                "pkg-dir": "^5.0.0",
-                "schema-utils": "^3.0.0",
+                "schema-utils": "^3.1.0",
                 "tapable": "^2.1.1",
-                "terser-webpack-plugin": "^5.0.3",
-                "watchpack": "^2.0.0",
-                "webpack-sources": "^2.1.1"
+                "terser-webpack-plugin": "^5.1.3",
+                "watchpack": "^2.4.0",
+                "webpack-sources": "^3.2.3"
             }
         },
         "webpack-cli": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.3.1.tgz",
-            "integrity": "sha512-/F4+9QNZM/qKzzL9/06Am8NXIkGV+/NqQ62Dx7DSqudxxpAgBqYn6V7+zp+0Y7JuWksKUbczRY3wMTd+7Uj6OA==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.0.1.tgz",
+            "integrity": "sha512-S3KVAyfwUqr0Mo/ur3NzIp6jnerNpo7GUO6so51mxLi1spqsA17YcMXy0WOIJtBSnj748lthxC6XLbNKh/ZC+A==",
             "dev": true,
             "requires": {
                 "@discoveryjs/json-ext": "^0.5.0",
-                "@webpack-cli/info": "^1.2.1",
-                "@webpack-cli/serve": "^1.2.1",
-                "colorette": "^1.2.1",
-                "commander": "^6.2.0",
-                "enquirer": "^2.3.6",
-                "execa": "^5.0.0",
+                "@webpack-cli/configtest": "^2.0.1",
+                "@webpack-cli/info": "^2.0.1",
+                "@webpack-cli/serve": "^2.0.1",
+                "colorette": "^2.0.14",
+                "commander": "^9.4.1",
+                "cross-spawn": "^7.0.3",
+                "envinfo": "^7.7.3",
                 "fastest-levenshtein": "^1.0.12",
                 "import-local": "^3.0.2",
-                "interpret": "^2.2.0",
-                "rechoir": "^0.7.0",
-                "v8-compile-cache": "^2.2.0",
-                "webpack-merge": "^4.2.2"
+                "interpret": "^3.1.1",
+                "rechoir": "^0.8.0",
+                "webpack-merge": "^5.7.3"
             },
             "dependencies": {
                 "commander": {
-                    "version": "6.2.1",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-                    "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+                    "version": "9.4.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
+                    "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
                     "dev": true
                 }
             }
         },
         "webpack-merge": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
-            "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
+            "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
             "dev": true,
             "requires": {
-                "lodash": "^4.17.15"
+                "clone-deep": "^4.0.1",
+                "wildcard": "^2.0.0"
             }
         },
         "webpack-sources": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.2.0.tgz",
-            "integrity": "sha512-bQsA24JLwcnWGArOKUxYKhX3Mz/nK1Xf6hxullKERyktjNMC4x8koOeaDNTA2fEJ09BdWLbM/iTW0ithREUP0w==",
-            "dev": true,
-            "requires": {
-                "source-list-map": "^2.0.1",
-                "source-map": "^0.6.1"
-            }
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+            "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+            "dev": true
         },
         "which": {
             "version": "2.0.2",
@@ -4041,6 +3778,12 @@
             "requires": {
                 "isexe": "^2.0.0"
             }
+        },
+        "wildcard": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
+            "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
+            "dev": true
         },
         "workerpool": {
             "version": "6.2.1",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
         "chai": "^4.2.0",
         "mocha": "^10.0.0",
         "rimraf": "^3.0.2",
-        "webpack": "^5.11.1",
-        "webpack-cli": "^4.3.1"
+        "webpack": "^5.75.0",
+        "webpack-cli": "^5.0.1"
     },
     "optionalDependencies": {
         "fsevents": "^2.3.2"


### PR DESCRIPTION
Probably using webpack hash algorithm is relied on OpenSSL which is EOL.
Webpack v5.54.0+ does not rely on OpenSSL.

cf. 
- https://nodejs.org/en/blog/announcements/nodejs16-eol/
- https://stackoverflow.com/questions/69394632/webpack-build-failing-with-err-ossl-evp-unsupported

### Issue

ref. #28


### ✅  Run Test in Node `v18.12.1`

```sh
% npm run test  

> webpack-watched-glob-entries-plugin@2.2.5 test
> npm run cleanup && npm run test:main && npm run cleanup && npm run test:basename && npm run cleanup

> webpack-watched-glob-entries-plugin@2.2.5 cleanup
> rimraf ./test/dist

> webpack-watched-glob-entries-plugin@2.2.5 test:main
> npm run build:main && mocha  ./test/tests/output.test.js

> webpack-watched-glob-entries-plugin@2.2.5 build:main
> webpack --config test/webpack.config.js

asset Third/Third/third.js 1.3 KiB [emitted] (name: Third/Third/third)
asset Second/second.js 1.28 KiB [emitted] (name: Second/second)
asset first.js 1.23 KiB [emitted] (name: first)
./test/src/first.js 1 bytes [built] [code generated]
./test/src/Second/second.js 1 bytes [built] [code generated]
./test/src/Third/Third/third.js 1 bytes [built] [code generated]
webpack 5.75.0 compiled successfully in 49 ms

  Output
    ✔ must create the first output file
    ✔ must create the second output file
    ✔ must create the third output file

  3 passing (2ms)

> webpack-watched-glob-entries-plugin@2.2.5 cleanup
> rimraf ./test/dist

> webpack-watched-glob-entries-plugin@2.2.5 test:basename
> npm run build:basename && mocha  ./test/tests/output.basename.test.js

> webpack-watched-glob-entries-plugin@2.2.5 build:basename
> webpack --config test/webpack.basename.config.js

asset third.js 1.3 KiB [emitted] (name: third)
asset second.js 1.28 KiB [emitted] (name: second)
asset first.js 1.23 KiB [emitted] (name: first)
./test/src/first.js 1 bytes [built] [code generated]
./test/src/Second/second.js 1 bytes [built] [code generated]
./test/src/Third/Third/third.js 1 bytes [built] [code generated]
webpack 5.75.0 compiled successfully in 44 ms

  Output
    ✔ must create the first output file without the full path
    ✔ must create the second output file without the full path
    ✔ must create the third output file without the full path

  3 passing (3ms)

> webpack-watched-glob-entries-plugin@2.2.5 cleanup
> rimraf ./test/dist
``