### PR TITLE
CI Node.js CI: Use --omit=optional

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,5 +23,5 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: npm ci --no-optional
+    - run: npm ci --omit=optional
     - run: npm test


### PR DESCRIPTION
https://github.com/Milanzor/webpack-watched-glob-entries-plugin/actions/runs/12008780500/job/33472202411

```
npm warn config optional Use `--omit=optional` to exclude optional dependencies, or
npm warn config `--include=optional` to include them.
npm warn config
npm warn config       Default value does install optional deps unless otherwise omitted.
```

To fix the above Warning, I use `--omit=optional` instead of `--no-optional`.