### PR TITLE
package.json: Fix repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
     "version": "3.0.2",
     "description": "Webpack plugin to glob directories for entry files and also watch them for changes",
     "main": "index.js",
-    "repository": "https://github.com/Milanzor/webpack-watched-glob-entries-plugin",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/Milanzor/webpack-watched-glob-entries-plugin.git"
+    },
     "author": "Milan van As <milanvanas@gmail.com>",
     "license": "MIT",
     "scripts": {


### PR DESCRIPTION
https://github.com/Milanzor/webpack-watched-glob-entries-plugin/actions/runs/12010578296/job/33477719881

```
npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm warn publish errors corrected:
npm warn publish "repository" was changed from a string to an object
npm warn publish "repository.url" was normalized to "git+https://github.com/Milanzor/webpack-watched-glob-entries-plugin.git"
```

I fix `repository` section in `package.json` using `npm pkg fix` command.