### PR TITLE
Add NodeJS v24 Support

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,26 +2,25 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x, 21.x, 22.x]
+        node-version: [14.x, 16.x, 18.x, 20.x, 21.x, 22.x, 24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-    - run: npm ci --omit=optional
-    - run: npm test
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - run: npm ci --omit=optional
+      - run: npm test

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm publish

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "webpack-watched-glob-entries-plugin",
-    "version": "3.0.0",
+    "version": "3.0.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "webpack-watched-glob-entries-plugin",
-            "version": "3.0.0",
+            "version": "3.0.2",
             "license": "MIT",
             "dependencies": {
                 "glob": "^10.3.10",
@@ -20,7 +20,7 @@
                 "webpack-cli": "^5.1.4"
             },
             "engines": {
-                "node": ">=14.0.0 <=22"
+                "node": ">=14.0.0 <=24"
             },
             "optionalDependencies": {
                 "fsevents": "^2.3.3"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "glob-parent": ">=6.0.2"
     },
     "engines": {
-        "node": ">=14.0.0 <=22"
+        "node": ">=14.0.0 <=24"
     },
     "devDependencies": {
         "chai": "^4.3.10",


### PR DESCRIPTION
I don't see anything that would _not_ work in v24, ran the test in the repo, and I am also using v3 in my repo with NodeJS v24 with no issue.